### PR TITLE
Fix ident 10 => 8

### DIFF
--- a/charts/hive-metastore/templates/statefulset.yaml
+++ b/charts/hive-metastore/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
         - "-c"
         - "/opt/hive/bin/hive --service metastore"
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.resources | indent 8 }}
         # readinessProbe:
         #   httpGet:
         #     path: /


### PR DESCRIPTION
Fix ident 10 => 8 so we can configure custom env variables, readinessProbe, livenessProbe


Error: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.containers[0].resources): unknown field "readinessProbe" in io.k8s.api.core.v1.ResourceRequirements